### PR TITLE
Fix documentation: Correct default value of planner_interval from 4 to 1

### DIFF
--- a/docs/customize/agent-settings.mdx
+++ b/docs/customize/agent-settings.mdx
@@ -48,7 +48,6 @@ agent = Agent(
   - For GPT-4o, image processing costs approximately 800-1000 tokens (~$0.002 USD) per image (but this depends on the defined screen size)
 - `save_conversation_path`: Path to save the complete conversation history. Useful for debugging.
 - `system_prompt_class`: Custom system prompt class. See <a href="/customize/system-prompt">System Prompt</a> for customization options.
-- 
 
 <Note>
   Vision capabilities are recommended for better web interaction understanding,
@@ -204,7 +203,7 @@ agent = Agent(
 
 - `planner_llm`: A LangChain chat model instance used for high-level task planning. Can be a smaller/cheaper model than the main LLM.
 - `use_vision_for_planner`: Enable/disable vision capabilities for the planner model. Defaults to `True`.
-- `planner_interval`: Number of steps between planning phases. Defaults to `4`.
+- `planner_interval`: Number of steps between planning phases. Defaults to `1`.
 
 Using a separate planner model can help:
 - Reduce costs by using a smaller model for high-level planning


### PR DESCRIPTION
The documentation incorrectly states that the default value of `planner_interval` is **4**, whereas the actual default value in the code is **1**.

#### **Issue**
In the documentation:
> `planner_interval: Number of steps between planning phases. Defaults to 4.`

However, in the `Agent` class constructor, the default value is explicitly set to `1`:

https://github.com/browser-use/browser-use/blob/471ecb1009228b0d4280dd1b3952e8937f437a32/browser_use/agent/service.py#L107

```python
planner_interval: int = 1  # Run planner every N steps
```

#### **Fix**
Updated the documentation to reflect the correct default value (`1`) to match the actual implementation.
